### PR TITLE
Fixes RT#90942 Class::MOP::load_class deprecation warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -52,6 +52,7 @@ Pod::Usage = 0
 Proc::ProcessTable = 0.39
 Time::HiRes = 0
 YAML::Any = 0
+Class::Load = 0.20
 
 [Prereqs / RuntimeRecommends]
 Unix::Lsof = 0.0.9

--- a/lib/Server/Control.pm
+++ b/lib/Server/Control.pm
@@ -4,6 +4,7 @@ use File::Basename;
 use File::Slurp qw(read_file);
 use File::Spec::Functions qw(catdir);
 use File::Which;
+use Class::Load;
 use Getopt::Long;
 use Hash::MoreUtils qw(slice_def);
 use IPC::System::Simple qw();
@@ -492,7 +493,7 @@ sub handle_cli {
             substr( $subclass, 0, 1 ) eq '+'
           ? substr( $subclass, 1 )
           : "Server::Control::$subclass";
-        Class::MOP::load_class($full_subclass);
+        Class::Load::load_class($full_subclass);
         return $full_subclass->handle_cli();
     }
 

--- a/lib/Server/Control/HTTPServerSimple.pm
+++ b/lib/Server/Control/HTTPServerSimple.pm
@@ -4,6 +4,7 @@ use Moose;
 use MooseX::StrictConstructor;
 use Moose::Meta::Class;
 use Moose::Util::TypeConstraints;
+use Class::Load;
 use strict;
 use warnings;
 
@@ -39,7 +40,7 @@ sub _build_server {
     my $self = shift;
 
     my $server_class = $self->server_class;
-    Class::MOP::load_class($server_class);
+    Class::Load::load_class($server_class);
     unless ( $server_class->can('net_server')
         && defined( $server_class->net_server() ) )
     {

--- a/lib/Server/Control/NetServer.pm
+++ b/lib/Server/Control/NetServer.pm
@@ -2,6 +2,7 @@ package Server::Control::NetServer;
 use Carp;
 use Moose;
 use MooseX::StrictConstructor;
+use Class::Load;
 use strict;
 use warnings;
 
@@ -62,7 +63,7 @@ sub do_start {
     my $child = fork;
     croak "Can't fork: $!" unless defined($child);
     if ( !$child ) {
-        Class::MOP::load_class( $self->net_server_class );
+        Class::Load::load_class( $self->net_server_class );
         $self->net_server_class->run(
             background => 1,
             %{ $self->net_server_params }

--- a/lib/Server/Control/t/Base.pm
+++ b/lib/Server/Control/t/Base.pm
@@ -5,6 +5,7 @@ use File::Temp qw(tempfile tempdir);
 use Guard;
 use HTTP::Server::Simple;
 use Log::Any;
+use Class::Load;
 use Net::Server;
 use POSIX qw(geteuid getegid);
 use Server::Control::Util
@@ -111,7 +112,7 @@ sub test_stopstart : Tests(16) {
 
     # Make sure stopstart aborts when stop fails
     my $orig_class  = ref($ctl);
-    my $unstoppable = Class::MOP::Class->create_anon_class(
+    my $unstoppable = Class::Load::Class->create_anon_class(
         superclasses => [$orig_class],
         methods      => {
             do_stop => sub { die "can't stop!" }


### PR DESCRIPTION
This fixes RT#90942: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90942
